### PR TITLE
Added permissive license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,7 @@
-This is free and unencumbered software released into the public domain.
+Copyright (c) 2024 Daniel Fichtinger and contributors. See the repository's revision history for details.
 
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <https://unlicense.org/>
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024 Daniel Fichtinger and contributors. See the repository's revision history for details.
+Copyright © 2025 Daniel Fichtinger
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Coding is already hard on the brain, so it should at least be easy on the eyes. 
   - [Nvim-colorizer](#nvim-colorizer)
 - [Acknowledgements](#acknowledgements)
 - [Roadmap](#roadmap)
-- [Unlicense](#unlicense)
 - [Contributing](#contributing)
 <!--toc:end-->
 
@@ -217,10 +216,6 @@ Ashen was inspired by [nvim-noirbuddy](https://github.com/jesseleite/nvim-noirbu
 - [ ] Compilation and caching of theme to improve startup time (like [kanagawa](https://github.com/rebelot/kanagawa.nvim))
 - [ ] Kitty, Wezterm, Xresources, Pywal16 extras.
 
-## Unlicense
-
-Ashen is relinquished into the public domain. For more information, please see the [unlicense](./LICENSE).
-
 ## Contributing
 
-I welcome contributions. If you want a certain plugin to be supported, please open and issue and I'll get to it as soon as I can. Please note that by contributing _code_ to this repository, you agree to [release it into the public domain.](./LICENSE).
+I welcome contributions. If you want a certain plugin to be supported, please open and issue and I'll get to it as soon as I can.


### PR DESCRIPTION
I'm changing the license from the Unlicense to MIT in order to better comply with the standards followed by other Neovim plugins. I also want anyone to be able to contribute to Ashen, and employees of certain companies like Google are not allowed to contribute to projects with an Unlicense. 