### PR TITLE
Add border colors for kitty theme

### DIFF
--- a/extras/kitty/Ashen.conf
+++ b/extras/kitty/Ashen.conf
@@ -22,3 +22,6 @@ color13               #a7a7a7
 color14               #b4b4b4
 color15               #d5d5d5
 
+active_border_color     #B14242
+inactive_border_color   #949494
+bell_border_color       #D87C4A


### PR DESCRIPTION
The default border color for splits is bright green which of course doesn't fit well with the ashen theme 😆 